### PR TITLE
Issue #3522147: Fix parsing nested sitemaps on "/sitemap.xml"

### DIFF
--- a/src/Service/ContentAnalyzer.php
+++ b/src/Service/ContentAnalyzer.php
@@ -199,24 +199,46 @@ class ContentAnalyzer {
   /**
    * Gets the sitemap URLs.
    *
+   * @param string|null $sitemap_url
+   *   The sitemap URL to fetch. Defaults to /sitemap.xml.
+   *
    * @return array
    *   An array containing URLs from the sitemap and any error messages.
    */
-  public function getSitemapUrls(): array {
+  public function getSitemapUrls(?string $sitemap_url = NULL): array {
     try {
-      // Generate absolute URL for sitemap.xml.
-      $sitemap_url = Url::fromUserInput('/sitemap.xml')
-        ->setAbsolute()
-        ->toString();
+      if (!$sitemap_url) {
+        // Generate absolute URL for sitemap.xml.
+        $sitemap_url = Url::fromUserInput('/sitemap.xml')
+          ->setAbsolute()
+          ->toString();
+      }
 
       $response = $this->httpClient->request('GET', $sitemap_url);
       $xml_content = $response->getBody()->getContents();
 
       if ($xml = simplexml_load_string($xml_content)) {
         $urls = [];
-        foreach ($xml->url as $url) {
-          $urls[] = (string) $url->loc;
+
+        // Get URLs from sitemap.xml.
+        if (isset($xml->url)) {
+          foreach ($xml->url as $url) {
+            $urls[] = (string) $url->loc;
+          }
         }
+
+        // If there are nested sitemaps, fetch them recursively.
+        if (isset($xml->sitemap)) {
+          foreach ($xml->sitemap as $sitemap) {
+            $recursive_result = $this->getSitemapUrls((string) $sitemap->loc);
+            if ($recursive_result['error']) {
+              return $recursive_result;
+            }
+
+            $urls = array_merge($urls, $recursive_result['urls']);
+          }
+        }
+
         return [
           'urls' => $urls,
           'error' => NULL,

--- a/src/Service/ContentAnalyzer.php
+++ b/src/Service/ContentAnalyzer.php
@@ -199,66 +199,112 @@ class ContentAnalyzer {
   /**
    * Gets the sitemap URLs.
    *
-   * @param string|null $sitemap_url
-   *   The sitemap URL to fetch. Defaults to /sitemap.xml.
+   * This method processes sitemaps iteratively to avoid recursion depth issues.
+   * It handles two types of XML structures:
+   *   1. <urlset>: Contains direct page URLs.
+   *   2. <sitemapindex>: Contains links to other sitemaps.
    *
    * @return array
-   *   An array containing URLs from the sitemap and any error messages.
+   *   An array containing:
+   *   - 'urls': (array) A flat list of all discovered URLs.
+   *   - 'error': (string|null) Error message if fetching or parsing failed.
    */
-  public function getSitemapUrls(?string $sitemap_url = NULL): array {
-    try {
-      if (!$sitemap_url) {
-        // Generate absolute URL for sitemap.xml.
-        $sitemap_url = Url::fromUserInput('/sitemap.xml')
-          ->setAbsolute()
-          ->toString();
+  public function getSitemapUrls(): array {
+    // Generate absolute URL for sitemap.xml.
+    $sitemap_url = Url::fromUserInput('/sitemap.xml')
+      ->setAbsolute()
+      ->toString();
+
+    $urls = [];
+    // Queue of sitemap URLs to be processed.
+    $sitemaps_to_process = [$sitemap_url];
+    // Track processed sitemaps to prevent infinite loops
+    // from circular references.
+    $processed_sitemaps = [];
+
+    while (!empty($sitemaps_to_process)) {
+      $current_url = array_shift($sitemaps_to_process);
+
+      // Avoid infinite loops if sitemaps reference each other.
+      if (isset($processed_sitemaps[$current_url])) {
+        continue;
+      }
+      $processed_sitemaps[$current_url] = TRUE;
+
+      $result = $this->fetchSitemapXml($current_url);
+
+      if ($result['error']) {
+        return [
+          'urls' => [],
+          'error' => $result['error'],
+        ];
       }
 
-      $response = $this->httpClient->request('GET', $sitemap_url);
+      $xml = $result['xml'];
+
+      // Case 1: The sitemap contains direct URLs (<urlset> structure).
+      if (isset($xml->url)) {
+        foreach ($xml->url as $url_entry) {
+          $urls[] = (string) $url_entry->loc;
+        }
+      }
+
+      // Case 2: The sitemap is an index pointing to other sitemaps
+      // (<sitemapindex> structure).
+      if (isset($xml->sitemap)) {
+        foreach ($xml->sitemap as $sub_sitemap) {
+          $sitemaps_to_process[] = (string) $sub_sitemap->loc;
+        }
+      }
+    }
+
+    return [
+      'urls' => $urls,
+      'error' => NULL,
+    ];
+  }
+
+  /**
+   * Fetches and parses a sitemap XML.
+   *
+   * @param string $url
+   *   The URL of the sitemap.
+   *
+   * @return array
+   *   An array with:
+   *   - 'xml': (SimpleXMLElement|null) The parsed XML object on success.
+   *   - 'error': (string|null) Error message on failure.
+   */
+  protected function fetchSitemapXml(string $url): array {
+    try {
+      // Fetch the XML content via HTTP.
+      $response = $this->httpClient->request('GET', $url);
       $xml_content = $response->getBody()->getContents();
 
+      // Attempt to parse the XML string.
       if ($xml = simplexml_load_string($xml_content)) {
-        $urls = [];
-
-        // Get URLs from sitemap.xml.
-        if (isset($xml->url)) {
-          foreach ($xml->url as $url) {
-            $urls[] = (string) $url->loc;
-          }
-        }
-
-        // If there are nested sitemaps, fetch them recursively.
-        if (isset($xml->sitemap)) {
-          foreach ($xml->sitemap as $sitemap) {
-            $recursive_result = $this->getSitemapUrls((string) $sitemap->loc);
-            if ($recursive_result['error']) {
-              return $recursive_result;
-            }
-
-            $urls = array_merge($urls, $recursive_result['urls']);
-          }
-        }
-
         return [
-          'urls' => $urls,
+          'xml' => $xml,
           'error' => NULL,
         ];
       }
 
       return [
-        'urls' => [],
+        'xml' => NULL,
         'error' => $this->t('The sitemap.xml file could not be parsed. Please ensure it contains valid XML.'),
       ];
     }
     catch (GuzzleException $e) {
+      // Handle HTTP-level errors (e.g., 404, connection issues).
       return [
-        'urls' => [],
+        'xml' => NULL,
         'error' => $this->t('Could not fetch sitemap.xml. Error: @error', ['@error' => $e->getMessage()]),
       ];
     }
     catch (\Exception $e) {
+      // Handle any other unexpected exceptions.
       return [
-        'urls' => [],
+        'xml' => NULL,
         'error' => $this->t('An unexpected error occurred while processing sitemap.xml. Error: @error', ['@error' => $e->getMessage()]),
       ];
     }


### PR DESCRIPTION
Issue - https://www.drupal.org/project/ai_content_strategy/issues/3522147

### Problem 
The [Simple XML sitemap](https://www.drupal.org/project/simple_sitemap) can generate the URLs in two different ways:
1. Without paginators (just a list of all URLs)
<img width="1721" height="444" alt="image" src="https://github.com/user-attachments/assets/8efa9dc6-13a2-41da-9727-05cb82110e86" />

2. With paginators (nested sitemaps) 
<img width="1332" height="468" alt="Screenshot 2026-01-16 at 17 39 10" src="https://github.com/user-attachments/assets/b4b73cab-ab90-42a8-948d-59c57935737b" />

The `Drupal\ai_content_strategy\Service\ContentAnalyzer::getSitemapUrls()` method can work only with the first case, but not with the second.

### Solution
Make the `Drupal\ai_content_strategy\Service\ContentAnalyzer::getSitemapUrls()` be able to work with nested sitemaps as well.

### How to reproduce
1. Install "DXPR CMS" with enabled modules: `simple_sitemap`, `ai_content_strategy`
2. Make sure you can see the full list of URLs on `/sitemap.xml`
3. On `/admin/config/search/simplesitemap/settings`, change the **"Maximum links in a sitemap"** setting to 5
4. On `/admin/config/search/simplesitemap`, click **"Rebuild queue & generate"**
5. Make sure you can see the list of nested sitemaps (pages) on `/sitemap.xml`
6. Execute the command and make sure there are no errors and the list of URLs is correct
```
drush php:eval "echo var_export(\Drupal::service('ai_content_strategy.content_analyzer')->getSitemapUrls(), TRUE);"
```