### PR TITLE
feat: add Drush commands for AI consumption with sitemap warnings

### DIFF
--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,0 +1,16 @@
+services:
+  ai_content_strategy.commands.sitemap:
+    class: Drupal\ai_content_strategy\Drush\Commands\SitemapCommands
+    arguments:
+      - '@ai_content_strategy.content_analyzer'
+    tags:
+      - { name: drush.command }
+
+  ai_content_strategy.commands.strategy:
+    class: Drupal\ai_content_strategy\Drush\Commands\StrategyCommands
+    arguments:
+      - '@ai_content_strategy.recommendation_storage'
+      - '@entity_type.manager'
+      - '@date.formatter'
+    tags:
+      - { name: drush.command }

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -3,6 +3,7 @@ services:
     class: Drupal\ai_content_strategy\Drush\Commands\SitemapCommands
     arguments:
       - '@ai_content_strategy.content_analyzer'
+      - '@entity_type.manager'
     tags:
       - { name: drush.command }
 

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -11,6 +11,5 @@ services:
     arguments:
       - '@ai_content_strategy.recommendation_storage'
       - '@entity_type.manager'
-      - '@date.formatter'
     tags:
       - { name: drush.command }

--- a/src/Drush/Commands/SitemapCommands.php
+++ b/src/Drush/Commands/SitemapCommands.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Drupal\ai_content_strategy\Drush\Commands;
 
 use Drupal\ai_content_strategy\Service\ContentAnalyzer;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * Drush commands for sitemap operations.
+ * Drush command for sitemap data.
  */
 class SitemapCommands extends DrushCommands {
 
@@ -19,6 +20,7 @@ class SitemapCommands extends DrushCommands {
    */
   public function __construct(
     protected readonly ContentAnalyzer $contentAnalyzer,
+    protected readonly EntityTypeManagerInterface $entityTypeManager,
   ) {
     parent::__construct();
   }
@@ -29,22 +31,50 @@ class SitemapCommands extends DrushCommands {
   public static function create(ContainerInterface $container): self {
     return new self(
       $container->get('ai_content_strategy.content_analyzer'),
+      $container->get('entity_type.manager'),
     );
   }
 
   /**
-   * Lists all URLs from the site's sitemap.xml as JSON.
+   * Gets sitemap URLs with content statistics as JSON.
    */
-  #[CLI\Command(name: 'acs:sitemap:urls', aliases: ['acs-su'])]
-  #[CLI\Help(description: 'Lists all URLs from sitemap.xml as JSON.')]
-  #[CLI\Usage(name: 'drush acs:sitemap:urls', description: 'Get all sitemap URLs')]
-  public function listSitemapUrls(): void {
-    $result = $this->contentAnalyzer->getSitemapUrls();
+  #[CLI\Command(name: 'acs:sitemap', aliases: ['acs-s'])]
+  #[CLI\Help(description: 'Gets sitemap URLs and content statistics as JSON.')]
+  #[CLI\Usage(name: 'drush acs:sitemap', description: 'Get sitemap with stats')]
+  public function getSitemap(): void {
+    // Get sitemap URLs.
+    $sitemapResult = $this->contentAnalyzer->getSitemapUrls();
 
-    if ($result['error']) {
+    // Get content statistics by type.
+    $nodeStorage = $this->entityTypeManager->getStorage('node');
+    $nodeTypeStorage = $this->entityTypeManager->getStorage('node_type');
+
+    $contentTypes = [];
+    $totalNodes = 0;
+
+    foreach ($nodeTypeStorage->loadMultiple() as $type) {
+      $count = $nodeStorage->getQuery()
+        ->accessCheck(FALSE)
+        ->condition('type', $type->id())
+        ->condition('status', 1)
+        ->count()
+        ->execute();
+
+      $contentTypes[$type->id()] = [
+        'label' => $type->label(),
+        'count' => (int) $count,
+      ];
+      $totalNodes += $count;
+    }
+
+    if ($sitemapResult['error']) {
       $this->output()->writeln(json_encode([
         'success' => FALSE,
-        'error' => $result['error'],
+        'error' => $sitemapResult['error'],
+        'stats' => [
+          'total_nodes' => $totalNodes,
+          'content_types' => $contentTypes,
+        ],
         'urls' => [],
       ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
       return;
@@ -52,8 +82,12 @@ class SitemapCommands extends DrushCommands {
 
     $this->output()->writeln(json_encode([
       'success' => TRUE,
-      'url_count' => count($result['urls']),
-      'urls' => $result['urls'],
+      'stats' => [
+        'total_urls' => count($sitemapResult['urls']),
+        'total_nodes' => $totalNodes,
+        'content_types' => $contentTypes,
+      ],
+      'urls' => $sitemapResult['urls'],
     ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
   }
 

--- a/src/Drush/Commands/SitemapCommands.php
+++ b/src/Drush/Commands/SitemapCommands.php
@@ -39,8 +39,27 @@ class SitemapCommands extends DrushCommands {
    * Gets sitemap URLs with content statistics as JSON.
    */
   #[CLI\Command(name: 'acs:sitemap', aliases: ['acs-s'])]
-  #[CLI\Help(description: 'Gets sitemap URLs and content statistics as JSON.')]
-  #[CLI\Usage(name: 'drush acs:sitemap', description: 'Get sitemap with stats')]
+  #[CLI\Help(
+    description: 'Gets sitemap URLs and content statistics as JSON.',
+    synopsis: <<<'END'
+
+## Important: Base URL
+
+When running via Drush CLI, you must specify the site URL with -l:
+
+```bash
+drush acs:sitemap -l https://your-site.com
+```
+
+Without -l, Drupal may use the wrong base URL for fetching the sitemap.
+
+## Output
+
+Returns JSON with sitemap URLs and content statistics by type.
+
+END
+  )]
+  #[CLI\Usage(name: 'drush acs:sitemap -l https://example.com', description: 'Get sitemap (specify site URL)')]
   public function getSitemap(): void {
     // Get sitemap URLs.
     $sitemapResult = $this->contentAnalyzer->getSitemapUrls();
@@ -71,6 +90,7 @@ class SitemapCommands extends DrushCommands {
       $this->output()->writeln(json_encode([
         'success' => FALSE,
         'error' => $sitemapResult['error'],
+        'warning' => 'Sitemap unavailable. Content strategy recommendations may be inaccurate. Ensure sitemap is configured and use -l option to specify site URL.',
         'stats' => [
           'total_nodes' => $totalNodes,
           'content_types' => $contentTypes,
@@ -80,15 +100,27 @@ class SitemapCommands extends DrushCommands {
       return;
     }
 
-    $this->output()->writeln(json_encode([
+    $urlCount = count($sitemapResult['urls']);
+    $warning = NULL;
+    if ($urlCount < 5) {
+      $warning = "Sitemap contains only $urlCount URLs. Content strategy recommendations may be incomplete. Ensure your sitemap is properly configured.";
+    }
+
+    $output = [
       'success' => TRUE,
       'stats' => [
-        'total_urls' => count($sitemapResult['urls']),
+        'total_urls' => $urlCount,
         'total_nodes' => $totalNodes,
         'content_types' => $contentTypes,
       ],
       'urls' => $sitemapResult['urls'],
-    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    ];
+
+    if ($warning) {
+      $output['warning'] = $warning;
+    }
+
+    $this->output()->writeln(json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
   }
 
 }

--- a/src/Drush/Commands/SitemapCommands.php
+++ b/src/Drush/Commands/SitemapCommands.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\ai_content_strategy\Drush\Commands;
 
-use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
 use Drupal\ai_content_strategy\Service\ContentAnalyzer;
 use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
@@ -12,16 +11,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Drush commands for sitemap operations.
- *
- * Provides AI-optimized sitemap URL listing with JSON output support.
  */
 class SitemapCommands extends DrushCommands {
 
   /**
    * Constructs SitemapCommands.
-   *
-   * @param \Drupal\ai_content_strategy\Service\ContentAnalyzer $contentAnalyzer
-   *   The content analyzer service.
    */
   public function __construct(
     protected readonly ContentAnalyzer $contentAnalyzer,
@@ -39,243 +33,28 @@ class SitemapCommands extends DrushCommands {
   }
 
   /**
-   * Lists all URLs from the site's sitemap.xml.
+   * Lists all URLs from the site's sitemap.xml as JSON.
    */
-  #[CLI\Command(name: 'acs:sitemap:urls', aliases: ['acs-su', 'acs:sitemap'])]
-  #[CLI\Option(name: 'limit', description: 'Maximum number of URLs to return (default: all)')]
-  #[CLI\Option(name: 'offset', description: 'Number of URLs to skip (for pagination)')]
-  #[CLI\Help(
-    description: 'Lists all URLs from sitemap.xml. Handles sitemap indexes with multiple sub-sitemaps.',
-    synopsis: <<<'END'
-
-## Purpose
-
-Extracts all URLs from the site's sitemap.xml file. Designed for AI consumption
-to understand the full scope of a site's published content.
-
-## What This Command Does
-
-1. Fetches `/sitemap.xml` from the site
-2. Parses XML structure (handles both `<urlset>` and `<sitemapindex>`)
-3. Recursively processes nested sitemaps (sitemap indexes)
-4. Returns flat list of all discovered URLs
-5. Handles circular references safely
-
-## Sitemap Types Supported
-
-### Direct URL List (`<urlset>`)
-Standard sitemap containing page URLs directly:
-```xml
-<urlset>
-  <url><loc>https://example.com/page1</loc></url>
-  <url><loc>https://example.com/page2</loc></url>
-</urlset>
-```
-
-### Sitemap Index (`<sitemapindex>`)
-Index pointing to multiple sub-sitemaps:
-```xml
-<sitemapindex>
-  <sitemap><loc>https://example.com/sitemap-pages.xml</loc></sitemap>
-  <sitemap><loc>https://example.com/sitemap-posts.xml</loc></sitemap>
-</sitemapindex>
-```
-
-## Options
-
-### `--limit`
-Maximum URLs to return. Useful for large sites or testing.
-```bash
---limit=100
-```
-
-### `--offset`
-Skip first N URLs (for pagination on large sitemaps).
-```bash
---offset=100
-```
-
-## Examples
-
-### Get All URLs
-```bash
-drush acs:sitemap:urls --format=json
-```
-
-### Get First 50 URLs
-```bash
-drush acs:sitemap:urls --limit=50 --format=json
-```
-
-### Paginate Through Large Sitemap
-```bash
-# First 100
-drush acs:sitemap:urls --limit=100 --format=json
-
-# Next 100
-drush acs:sitemap:urls --limit=100 --offset=100 --format=json
-```
-
-### Count Total URLs
-```bash
-drush acs:sitemap:urls --format=json | jq '.[] | length'
-```
-
-### Filter URLs by Pattern
-```bash
-drush acs:sitemap:urls --format=json | jq '.[] | select(.url | contains("/blog/"))'
-```
-
-## Output Structure
-
-```json
-[
-  {"url": "https://example.com/"},
-  {"url": "https://example.com/about"},
-  {"url": "https://example.com/blog/post-1"},
-  {"url": "https://example.com/blog/post-2"}
-]
-```
-
-## Use Cases for AI Assistants
-
-1. **Site Audit**: Get complete URL inventory before content analysis
-2. **Content Gap Analysis**: Compare sitemap URLs against content strategy
-3. **SEO Analysis**: Identify URL patterns and structure
-4. **Migration Planning**: Inventory all pages before migration
-5. **Broken Link Detection**: Get URL list for validation
-
-## Error Handling
-
-### Sitemap Not Found
-```json
-{
-  "success": false,
-  "error": "Could not fetch sitemap.xml. Error: 404 Not Found"
-}
-```
-
-### Invalid XML
-```json
-{
-  "success": false,
-  "error": "The sitemap.xml file could not be parsed. Please ensure it contains valid XML."
-}
-```
-
-## Requirements
-
-- Site must have a sitemap.xml at the root
-- Sitemap must be publicly accessible (no authentication)
-- Compatible with: simple_sitemap, xmlsitemap, or any standard sitemap
-
-## Related Commands
-
-- `acs:content-strategy:analyze` - Analyze content using sitemap URLs
-
-END
-  )]
-  #[CLI\Usage(name: 'drush acs:sitemap:urls --format=json', description: 'Get all sitemap URLs as JSON')]
-  #[CLI\Usage(name: 'drush acs:sitemap:urls --limit=50 --format=json', description: 'Get first 50 URLs')]
-  #[CLI\Usage(name: 'drush acs:sitemap:urls --limit=100 --offset=100', description: 'Paginate (skip 100, get next 100)')]
-  #[CLI\FieldLabels(labels: [
-    'url' => 'URL',
-  ])]
-  #[CLI\DefaultFields(fields: ['url'])]
-  public function listSitemapUrls(
-    array $options = [
-      'limit' => NULL,
-      'offset' => 0,
-    ],
-  ): RowsOfFields {
+  #[CLI\Command(name: 'acs:sitemap:urls', aliases: ['acs-su'])]
+  #[CLI\Help(description: 'Lists all URLs from sitemap.xml as JSON.')]
+  #[CLI\Usage(name: 'drush acs:sitemap:urls', description: 'Get all sitemap URLs')]
+  public function listSitemapUrls(): void {
     $result = $this->contentAnalyzer->getSitemapUrls();
 
     if ($result['error']) {
-      throw new \RuntimeException($result['error']);
-    }
-
-    $urls = $result['urls'];
-
-    // Apply offset.
-    $offset = (int) $options['offset'];
-    if ($offset > 0) {
-      $urls = array_slice($urls, $offset);
-    }
-
-    // Apply limit.
-    if ($options['limit'] !== NULL) {
-      $limit = (int) $options['limit'];
-      $urls = array_slice($urls, 0, $limit);
-    }
-
-    // Format for RowsOfFields output.
-    $rows = array_map(fn($url) => ['url' => $url], $urls);
-
-    return new RowsOfFields($rows);
-  }
-
-  /**
-   * Gets sitemap statistics without listing all URLs.
-   */
-  #[CLI\Command(name: 'acs:sitemap:stats', aliases: ['acs-ss'])]
-  #[CLI\Help(
-    description: 'Gets sitemap statistics (URL count) without returning all URLs.',
-    synopsis: <<<'END'
-
-## Purpose
-
-Quick check of sitemap size without downloading all URLs.
-Useful for understanding site scale before full sitemap fetch.
-
-## Output
-
-```json
-{
-  "success": true,
-  "url_count": 1250,
-  "sitemap_url": "https://example.com/sitemap.xml"
-}
-```
-
-## Examples
-
-```bash
-drush acs:sitemap:stats --format=json
-```
-
-## Use Cases
-
-- Quick site size assessment
-- Verify sitemap is accessible
-- Plan pagination strategy for large sitemaps
-
-END
-  )]
-  #[CLI\Usage(name: 'drush acs:sitemap:stats --format=json', description: 'Get sitemap URL count')]
-  #[CLI\FieldLabels(labels: [
-    'success' => 'Success',
-    'url_count' => 'URL Count',
-    'sitemap_url' => 'Sitemap URL',
-    'error' => 'Error',
-  ])]
-  public function getSitemapStats(): array {
-    $result = $this->contentAnalyzer->getSitemapUrls();
-
-    if ($result['error']) {
-      return [
+      $this->output()->writeln(json_encode([
         'success' => FALSE,
-        'url_count' => 0,
-        'sitemap_url' => '',
         'error' => $result['error'],
-      ];
+        'urls' => [],
+      ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+      return;
     }
 
-    return [
+    $this->output()->writeln(json_encode([
       'success' => TRUE,
       'url_count' => count($result['urls']),
-      'sitemap_url' => \Drupal::request()->getSchemeAndHttpHost() . '/sitemap.xml',
-      'error' => NULL,
-    ];
+      'urls' => $result['urls'],
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
   }
 
 }

--- a/src/Drush/Commands/SitemapCommands.php
+++ b/src/Drush/Commands/SitemapCommands.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ai_content_strategy\Drush\Commands;
+
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Drupal\ai_content_strategy\Service\ContentAnalyzer;
+use Drush\Attributes as CLI;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Drush commands for sitemap operations.
+ *
+ * Provides AI-optimized sitemap URL listing with JSON output support.
+ */
+class SitemapCommands extends DrushCommands {
+
+  /**
+   * Constructs SitemapCommands.
+   *
+   * @param \Drupal\ai_content_strategy\Service\ContentAnalyzer $contentAnalyzer
+   *   The content analyzer service.
+   */
+  public function __construct(
+    protected readonly ContentAnalyzer $contentAnalyzer,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('ai_content_strategy.content_analyzer'),
+    );
+  }
+
+  /**
+   * Lists all URLs from the site's sitemap.xml.
+   */
+  #[CLI\Command(name: 'acs:sitemap:urls', aliases: ['acs-su', 'acs:sitemap'])]
+  #[CLI\Option(name: 'limit', description: 'Maximum number of URLs to return (default: all)')]
+  #[CLI\Option(name: 'offset', description: 'Number of URLs to skip (for pagination)')]
+  #[CLI\Help(
+    description: 'Lists all URLs from sitemap.xml. Handles sitemap indexes with multiple sub-sitemaps.',
+    synopsis: <<<'END'
+
+## Purpose
+
+Extracts all URLs from the site's sitemap.xml file. Designed for AI consumption
+to understand the full scope of a site's published content.
+
+## What This Command Does
+
+1. Fetches `/sitemap.xml` from the site
+2. Parses XML structure (handles both `<urlset>` and `<sitemapindex>`)
+3. Recursively processes nested sitemaps (sitemap indexes)
+4. Returns flat list of all discovered URLs
+5. Handles circular references safely
+
+## Sitemap Types Supported
+
+### Direct URL List (`<urlset>`)
+Standard sitemap containing page URLs directly:
+```xml
+<urlset>
+  <url><loc>https://example.com/page1</loc></url>
+  <url><loc>https://example.com/page2</loc></url>
+</urlset>
+```
+
+### Sitemap Index (`<sitemapindex>`)
+Index pointing to multiple sub-sitemaps:
+```xml
+<sitemapindex>
+  <sitemap><loc>https://example.com/sitemap-pages.xml</loc></sitemap>
+  <sitemap><loc>https://example.com/sitemap-posts.xml</loc></sitemap>
+</sitemapindex>
+```
+
+## Options
+
+### `--limit`
+Maximum URLs to return. Useful for large sites or testing.
+```bash
+--limit=100
+```
+
+### `--offset`
+Skip first N URLs (for pagination on large sitemaps).
+```bash
+--offset=100
+```
+
+## Examples
+
+### Get All URLs
+```bash
+drush acs:sitemap:urls --format=json
+```
+
+### Get First 50 URLs
+```bash
+drush acs:sitemap:urls --limit=50 --format=json
+```
+
+### Paginate Through Large Sitemap
+```bash
+# First 100
+drush acs:sitemap:urls --limit=100 --format=json
+
+# Next 100
+drush acs:sitemap:urls --limit=100 --offset=100 --format=json
+```
+
+### Count Total URLs
+```bash
+drush acs:sitemap:urls --format=json | jq '.[] | length'
+```
+
+### Filter URLs by Pattern
+```bash
+drush acs:sitemap:urls --format=json | jq '.[] | select(.url | contains("/blog/"))'
+```
+
+## Output Structure
+
+```json
+[
+  {"url": "https://example.com/"},
+  {"url": "https://example.com/about"},
+  {"url": "https://example.com/blog/post-1"},
+  {"url": "https://example.com/blog/post-2"}
+]
+```
+
+## Use Cases for AI Assistants
+
+1. **Site Audit**: Get complete URL inventory before content analysis
+2. **Content Gap Analysis**: Compare sitemap URLs against content strategy
+3. **SEO Analysis**: Identify URL patterns and structure
+4. **Migration Planning**: Inventory all pages before migration
+5. **Broken Link Detection**: Get URL list for validation
+
+## Error Handling
+
+### Sitemap Not Found
+```json
+{
+  "success": false,
+  "error": "Could not fetch sitemap.xml. Error: 404 Not Found"
+}
+```
+
+### Invalid XML
+```json
+{
+  "success": false,
+  "error": "The sitemap.xml file could not be parsed. Please ensure it contains valid XML."
+}
+```
+
+## Requirements
+
+- Site must have a sitemap.xml at the root
+- Sitemap must be publicly accessible (no authentication)
+- Compatible with: simple_sitemap, xmlsitemap, or any standard sitemap
+
+## Related Commands
+
+- `acs:content-strategy:analyze` - Analyze content using sitemap URLs
+
+END
+  )]
+  #[CLI\Usage(name: 'drush acs:sitemap:urls --format=json', description: 'Get all sitemap URLs as JSON')]
+  #[CLI\Usage(name: 'drush acs:sitemap:urls --limit=50 --format=json', description: 'Get first 50 URLs')]
+  #[CLI\Usage(name: 'drush acs:sitemap:urls --limit=100 --offset=100', description: 'Paginate (skip 100, get next 100)')]
+  #[CLI\FieldLabels(labels: [
+    'url' => 'URL',
+  ])]
+  #[CLI\DefaultFields(fields: ['url'])]
+  public function listSitemapUrls(
+    array $options = [
+      'limit' => NULL,
+      'offset' => 0,
+    ],
+  ): RowsOfFields {
+    $result = $this->contentAnalyzer->getSitemapUrls();
+
+    if ($result['error']) {
+      throw new \RuntimeException($result['error']);
+    }
+
+    $urls = $result['urls'];
+
+    // Apply offset.
+    $offset = (int) $options['offset'];
+    if ($offset > 0) {
+      $urls = array_slice($urls, $offset);
+    }
+
+    // Apply limit.
+    if ($options['limit'] !== NULL) {
+      $limit = (int) $options['limit'];
+      $urls = array_slice($urls, 0, $limit);
+    }
+
+    // Format for RowsOfFields output.
+    $rows = array_map(fn($url) => ['url' => $url], $urls);
+
+    return new RowsOfFields($rows);
+  }
+
+  /**
+   * Gets sitemap statistics without listing all URLs.
+   */
+  #[CLI\Command(name: 'acs:sitemap:stats', aliases: ['acs-ss'])]
+  #[CLI\Help(
+    description: 'Gets sitemap statistics (URL count) without returning all URLs.',
+    synopsis: <<<'END'
+
+## Purpose
+
+Quick check of sitemap size without downloading all URLs.
+Useful for understanding site scale before full sitemap fetch.
+
+## Output
+
+```json
+{
+  "success": true,
+  "url_count": 1250,
+  "sitemap_url": "https://example.com/sitemap.xml"
+}
+```
+
+## Examples
+
+```bash
+drush acs:sitemap:stats --format=json
+```
+
+## Use Cases
+
+- Quick site size assessment
+- Verify sitemap is accessible
+- Plan pagination strategy for large sitemaps
+
+END
+  )]
+  #[CLI\Usage(name: 'drush acs:sitemap:stats --format=json', description: 'Get sitemap URL count')]
+  #[CLI\FieldLabels(labels: [
+    'success' => 'Success',
+    'url_count' => 'URL Count',
+    'sitemap_url' => 'Sitemap URL',
+    'error' => 'Error',
+  ])]
+  public function getSitemapStats(): array {
+    $result = $this->contentAnalyzer->getSitemapUrls();
+
+    if ($result['error']) {
+      return [
+        'success' => FALSE,
+        'url_count' => 0,
+        'sitemap_url' => '',
+        'error' => $result['error'],
+      ];
+    }
+
+    return [
+      'success' => TRUE,
+      'url_count' => count($result['urls']),
+      'sitemap_url' => \Drupal::request()->getSchemeAndHttpHost() . '/sitemap.xml',
+      'error' => NULL,
+    ];
+  }
+
+}

--- a/src/Drush/Commands/StrategyCommands.php
+++ b/src/Drush/Commands/StrategyCommands.php
@@ -39,8 +39,145 @@ class StrategyCommands extends DrushCommands {
    * Gets the full content strategy report as JSON.
    */
   #[CLI\Command(name: 'acs:report', aliases: ['acs-r'])]
-  #[CLI\Help(description: 'Gets the full AI content strategy report as JSON.')]
+  #[CLI\Help(
+    description: 'Gets the full AI content strategy report as JSON. Returns the same data visible in the admin UI.',
+    synopsis: <<<'END'
+
+## Purpose
+
+Returns the complete AI-generated content strategy report as JSON. This is the
+read-only CLI equivalent of the admin UI at /admin/config/ai/content-strategy.
+
+Use this command to programmatically access content recommendations for:
+- AI coding assistants analyzing content needs
+- Automated reporting and dashboards
+- Integration with external tools
+- Content planning workflows
+
+## Output Structure
+
+```json
+{
+  "success": true,
+  "generated_at": "2024-01-30T12:00:00+00:00",
+  "pages_analyzed": 150,
+  "categories": {
+    "content_gaps": {
+      "label": "Content Gaps",
+      "cards": [
+        {
+          "uuid": "abc-123",
+          "title": "Product Comparison Pages",
+          "description": "Create comparison content...",
+          "priority": "high",
+          "content_ideas": [
+            {
+              "uuid": "def-456",
+              "text": "Compare Product A vs Product B",
+              "implemented": false,
+              "link": ""
+            },
+            {
+              "uuid": "ghi-789",
+              "text": "Feature comparison matrix",
+              "implemented": true,
+              "link": "/node/123"
+            }
+          ]
+        }
+      ]
+    }
+  }
+}
+```
+
+## Data Structure
+
+### Root Level
+| Field | Type | Description |
+|-------|------|-------------|
+| success | boolean | Whether report data exists |
+| generated_at | string | ISO 8601 timestamp of last generation |
+| pages_analyzed | integer | Number of sitemap URLs analyzed |
+| categories | object | Recommendation categories keyed by ID |
+
+### Category
+| Field | Type | Description |
+|-------|------|-------------|
+| label | string | Human-readable category name |
+| cards | array | Recommendation cards in this category |
+
+### Card
+| Field | Type | Description |
+|-------|------|-------------|
+| uuid | string | Unique identifier for the card |
+| title | string | Recommendation title/topic |
+| description | string | Detailed description |
+| priority | string | Priority level (high/medium/low) |
+| content_ideas | array | Specific actionable ideas |
+
+### Content Idea
+| Field | Type | Description |
+|-------|------|-------------|
+| uuid | string | Unique identifier for the idea |
+| text | string | The content idea description |
+| implemented | boolean | Whether this has been completed |
+| link | string | URL to created content (if implemented) |
+
+## Categories
+
+Categories are dynamically configured via the admin UI. Default categories include:
+- **Content Gaps**: Missing content opportunities
+- **Authority Topics**: Topics to build expertise in
+- **Trust Signals**: E-E-A-T improvement suggestions
+- **Content Series**: Related content groupings
+- **Expertise Demonstrations**: Ways to showcase knowledge
+
+## Examples
+
+### Basic Usage
+```bash
+drush acs:report
+```
+
+### Save to File
+```bash
+drush acs:report > strategy-report.json
+```
+
+### Extract with jq
+```bash
+# Get specific category
+drush acs:report | jq '.categories.content_gaps'
+
+# List all pending ideas
+drush acs:report | jq '[.categories[].cards[].content_ideas[] | select(.implemented == false)]'
+
+# Count ideas per category
+drush acs:report | jq '.categories | to_entries | map({key: .key, count: ([.value.cards[].content_ideas[]] | length)})'
+```
+
+## When No Report Exists
+
+If no report has been generated:
+```json
+{
+  "success": false,
+  "message": "No report generated yet. Visit /admin/config/ai/content-strategy.",
+  "categories": []
+}
+```
+
+Generate a report via the admin UI before using this command.
+
+## Related Commands
+
+- `acs:sitemap` - Get sitemap URLs and content statistics
+
+END
+  )]
   #[CLI\Usage(name: 'drush acs:report', description: 'Get full report as JSON')]
+  #[CLI\Usage(name: 'drush acs:report > report.json', description: 'Save report to file')]
   public function getReport(): void {
     $storedData = $this->recommendationStorage->getStoredData();
 

--- a/src/Drush/Commands/StrategyCommands.php
+++ b/src/Drush/Commands/StrategyCommands.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Drupal\ai_content_strategy\Drush\Commands;
 
 use Drupal\ai_content_strategy\Service\RecommendationStorageService;
-use Drupal\Core\Datetime\DateFormatterInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drush\Attributes as CLI;
 use Drush\Commands\DrushCommands;
@@ -13,25 +12,15 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Drush commands for AI content strategy reports.
- *
- * Provides AI-optimized access to content strategy recommendations.
  */
 class StrategyCommands extends DrushCommands {
 
   /**
    * Constructs StrategyCommands.
-   *
-   * @param \Drupal\ai_content_strategy\Service\RecommendationStorageService $recommendationStorage
-   *   The recommendation storage service.
-   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
-   *   The entity type manager.
-   * @param \Drupal\Core\Datetime\DateFormatterInterface $dateFormatter
-   *   The date formatter service.
    */
   public function __construct(
     protected readonly RecommendationStorageService $recommendationStorage,
     protected readonly EntityTypeManagerInterface $entityTypeManager,
-    protected readonly DateFormatterInterface $dateFormatter,
   ) {
     parent::__construct();
   }
@@ -43,327 +32,51 @@ class StrategyCommands extends DrushCommands {
     return new self(
       $container->get('ai_content_strategy.recommendation_storage'),
       $container->get('entity_type.manager'),
-      $container->get('date.formatter'),
     );
   }
 
   /**
-   * Gets the full content strategy report.
+   * Gets the full content strategy report as JSON.
    */
-  #[CLI\Command(name: 'acs:report', aliases: ['acs-r', 'acs:recommendations'])]
-  #[CLI\Help(
-    description: 'Gets the full AI content strategy report with all categories and recommendations.',
-    synopsis: <<<'END'
-
-## Purpose
-
-Returns the complete AI-generated content strategy report as structured JSON.
-Designed for AI assistant consumption to understand content recommendations.
-
-## What This Command Returns
-
-The full report includes:
-- Generation metadata (timestamp, pages analyzed)
-- All recommendation categories (dynamically configured)
-- Cards within each category with content ideas
-- Implementation status for each idea
-
-## Output Structure
-
-```json
-{
-  "success": true,
-  "generated_at": "2024-01-30T12:00:00+00:00",
-  "generated_ago": "2 hours ago",
-  "pages_analyzed": 150,
-  "categories": {
-    "content_gaps": {
-      "id": "content_gaps",
-      "label": "Content Gaps",
-      "description": "Identifies missing content opportunities...",
-      "weight": 0,
-      "card_count": 5,
-      "cards": [
-        {
-          "uuid": "abc-123-def",
-          "title": "Product Comparison Pages",
-          "content_ideas": [
-            {
-              "uuid": "ghi-456-jkl",
-              "text": "Create comparison: Product A vs Product B",
-              "implemented": false,
-              "link": ""
-            },
-            {
-              "uuid": "mno-789-pqr",
-              "text": "Add feature matrix table",
-              "implemented": true,
-              "link": "/node/123"
-            }
-          ]
-        }
-      ]
-    },
-    "topical_authority": {
-      "id": "topical_authority",
-      "label": "Topical Authority",
-      "description": "Build expertise in key topic areas...",
-      "weight": 1,
-      "card_count": 3,
-      "cards": [...]
-    }
-  },
-  "summary": {
-    "total_categories": 4,
-    "total_cards": 15,
-    "total_ideas": 47,
-    "implemented_ideas": 12,
-    "pending_ideas": 35
-  }
-}
-```
-
-## Category Structure
-
-Categories are **dynamically configured** via the admin UI at:
-`/admin/config/ai/content-strategy/categories`
-
-Each category has:
-- `id`: Machine name
-- `label`: Human-readable name
-- `description`: What this category analyzes
-- `weight`: Sort order
-- `cards`: Array of recommendation cards
-
-## Card Structure
-
-Each card represents a content recommendation:
-- `uuid`: Unique identifier for the card
-- `title`: The recommendation title/topic
-- `content_ideas`: Array of specific content ideas
-
-## Idea Structure
-
-Each idea is an actionable content suggestion:
-- `uuid`: Unique identifier
-- `text`: The content idea description
-- `implemented`: Boolean - whether this has been done
-- `link`: URL to the created content (if implemented)
-
-## Examples
-
-### Get Full Report
-```bash
-drush acs:report --format=json
-```
-
-### Save Report to File
-```bash
-drush acs:report --format=json > content-strategy.json
-```
-
-### Extract Specific Category with jq
-```bash
-drush acs:report --format=json | jq '.categories.content_gaps'
-```
-
-### Get Only Pending Ideas
-```bash
-drush acs:report --format=json | jq '[.categories[].cards[].content_ideas[] | select(.implemented == false)]'
-```
-
-### Count Ideas by Category
-```bash
-drush acs:report --format=json | jq '.categories | to_entries | map({category: .key, ideas: ([.value.cards[].content_ideas[]] | length)})'
-```
-
-## When No Report Exists
-
-If no report has been generated yet:
-```json
-{
-  "success": false,
-  "message": "No content strategy report has been generated yet. Generate one via the admin UI or API.",
-  "categories": {}
-}
-```
-
-## Use Cases for AI Assistants
-
-1. **Content Planning**: Review all recommendations before creating content
-2. **Progress Tracking**: Check which ideas have been implemented
-3. **Priority Assessment**: Analyze categories to focus efforts
-4. **Gap Analysis**: Identify areas needing more content
-5. **Reporting**: Generate status reports on content strategy progress
-
-## Related Commands
-
-- `acs:sitemap:urls` - Get all site URLs for context
-- `acs:sitemap:stats` - Quick site size check
-
-## Generating New Reports
-
-Reports are generated via:
-- Admin UI: `/admin/config/ai/content-strategy`
-- The generation process analyzes sitemap URLs with AI
-
-END
-  )]
-  #[CLI\Usage(name: 'drush acs:report --format=json', description: 'Get full content strategy report')]
-  #[CLI\Usage(name: 'drush acs:report --format=json > report.json', description: 'Save report to file')]
-  public function getReport(): array {
+  #[CLI\Command(name: 'acs:report', aliases: ['acs-r'])]
+  #[CLI\Help(description: 'Gets the full AI content strategy report as JSON.')]
+  #[CLI\Usage(name: 'drush acs:report', description: 'Get full report as JSON')]
+  public function getReport(): void {
     $storedData = $this->recommendationStorage->getStoredData();
 
-    // Handle case where no report exists.
     if ($storedData === NULL || empty($storedData['data'])) {
-      return [
+      $this->output()->writeln(json_encode([
         'success' => FALSE,
-        'message' => 'No content strategy report has been generated yet. Generate one via the admin UI at /admin/config/ai/content-strategy.',
-        'generated_at' => NULL,
-        'pages_analyzed' => NULL,
+        'message' => 'No report generated yet. Visit /admin/config/ai/content-strategy.',
         'categories' => [],
-        'summary' => [
-          'total_categories' => 0,
-          'total_cards' => 0,
-          'total_ideas' => 0,
-          'implemented_ideas' => 0,
-          'pending_ideas' => 0,
-        ],
-      ];
+      ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+      return;
     }
 
     $recommendations = $storedData['data'];
     $timestamp = $storedData['timestamp'] ?? NULL;
-    $pagesAnalyzed = $storedData['pages_analyzed'] ?? NULL;
 
-    // Load all enabled recommendation categories.
+    // Load enabled categories.
     $categoryEntities = $this->entityTypeManager
       ->getStorage('recommendation_category')
       ->loadByProperties(['status' => TRUE]);
-
-    // Sort by weight.
     uasort($categoryEntities, fn($a, $b) => $a->getWeight() <=> $b->getWeight());
 
-    // Build categories output.
+    // Build output.
     $categories = [];
-    $totalCards = 0;
-    $totalIdeas = 0;
-    $implementedIdeas = 0;
-
     foreach ($categoryEntities as $categoryId => $categoryEntity) {
-      $cards = $recommendations[$categoryId] ?? [];
-      $cardCount = count($cards);
-      $totalCards += $cardCount;
-
-      // Count ideas in this category.
-      foreach ($cards as &$card) {
-        $ideas = $card['content_ideas'] ?? [];
-        $totalIdeas += count($ideas);
-
-        // Normalize ideas and count implemented.
-        foreach ($ideas as $idea) {
-          if (is_array($idea) && !empty($idea['implemented'])) {
-            $implementedIdeas++;
-          }
-        }
-      }
-
       $categories[$categoryId] = [
-        'id' => $categoryId,
         'label' => $categoryEntity->label(),
-        'description' => $categoryEntity->getDescription(),
-        'weight' => $categoryEntity->getWeight(),
-        'card_count' => $cardCount,
-        'cards' => $cards,
+        'cards' => $recommendations[$categoryId] ?? [],
       ];
     }
 
-    // Format timestamp.
-    $generatedAt = NULL;
-    $generatedAgo = NULL;
-    if ($timestamp) {
-      $generatedAt = date('c', $timestamp);
-      $generatedAgo = $this->dateFormatter->formatTimeDiffSince($timestamp);
-    }
-
-    return [
+    $this->output()->writeln(json_encode([
       'success' => TRUE,
-      'generated_at' => $generatedAt,
-      'generated_ago' => $generatedAgo,
-      'pages_analyzed' => $pagesAnalyzed,
+      'generated_at' => $timestamp ? date('c', $timestamp) : NULL,
+      'pages_analyzed' => $storedData['pages_analyzed'] ?? NULL,
       'categories' => $categories,
-      'summary' => [
-        'total_categories' => count($categories),
-        'total_cards' => $totalCards,
-        'total_ideas' => $totalIdeas,
-        'implemented_ideas' => $implementedIdeas,
-        'pending_ideas' => $totalIdeas - $implementedIdeas,
-      ],
-    ];
-  }
-
-  /**
-   * Lists available recommendation categories.
-   */
-  #[CLI\Command(name: 'acs:categories', aliases: ['acs-c'])]
-  #[CLI\Help(
-    description: 'Lists all configured recommendation categories.',
-    synopsis: <<<'END'
-
-## Purpose
-
-Lists all recommendation categories configured in the system.
-Categories are dynamically configurable and define what types
-of content recommendations the AI generates.
-
-## Output Structure
-
-```json
-[
-  {
-    "id": "content_gaps",
-    "label": "Content Gaps",
-    "description": "Identifies missing content...",
-    "weight": 0,
-    "status": true
-  }
-]
-```
-
-## Examples
-
-```bash
-drush acs:categories --format=json
-```
-
-## Managing Categories
-
-Categories are managed at:
-`/admin/config/ai/content-strategy/categories`
-
-END
-  )]
-  #[CLI\Usage(name: 'drush acs:categories --format=json', description: 'List all categories')]
-  public function listCategories(): array {
-    $categoryEntities = $this->entityTypeManager
-      ->getStorage('recommendation_category')
-      ->loadMultiple();
-
-    // Sort by weight.
-    uasort($categoryEntities, fn($a, $b) => $a->getWeight() <=> $b->getWeight());
-
-    $categories = [];
-    foreach ($categoryEntities as $categoryEntity) {
-      $categories[] = [
-        'id' => $categoryEntity->id(),
-        'label' => $categoryEntity->label(),
-        'description' => $categoryEntity->getDescription(),
-        'weight' => $categoryEntity->getWeight(),
-        'status' => $categoryEntity->status(),
-      ];
-    }
-
-    return $categories;
+    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
   }
 
 }

--- a/src/Drush/Commands/StrategyCommands.php
+++ b/src/Drush/Commands/StrategyCommands.php
@@ -208,12 +208,21 @@ END
       ];
     }
 
-    $this->output()->writeln(json_encode([
+    $pagesAnalyzed = $storedData['pages_analyzed'] ?? NULL;
+
+    $output = [
       'success' => TRUE,
       'generated_at' => $timestamp ? date('c', $timestamp) : NULL,
-      'pages_analyzed' => $storedData['pages_analyzed'] ?? NULL,
+      'pages_analyzed' => $pagesAnalyzed,
       'categories' => $categories,
-    ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+    ];
+
+    // Add warning if sitemap had insufficient URLs.
+    if ($pagesAnalyzed !== NULL && $pagesAnalyzed < 5) {
+      $output['warning'] = "Report based on only $pagesAnalyzed pages. Recommendations may be incomplete. Ensure your sitemap is properly configured.";
+    }
+
+    $this->output()->writeln(json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
   }
 
 }

--- a/src/Drush/Commands/StrategyCommands.php
+++ b/src/Drush/Commands/StrategyCommands.php
@@ -1,0 +1,369 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\ai_content_strategy\Drush\Commands;
+
+use Drupal\ai_content_strategy\Service\RecommendationStorageService;
+use Drupal\Core\Datetime\DateFormatterInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drush\Attributes as CLI;
+use Drush\Commands\DrushCommands;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Drush commands for AI content strategy reports.
+ *
+ * Provides AI-optimized access to content strategy recommendations.
+ */
+class StrategyCommands extends DrushCommands {
+
+  /**
+   * Constructs StrategyCommands.
+   *
+   * @param \Drupal\ai_content_strategy\Service\RecommendationStorageService $recommendationStorage
+   *   The recommendation storage service.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   * @param \Drupal\Core\Datetime\DateFormatterInterface $dateFormatter
+   *   The date formatter service.
+   */
+  public function __construct(
+    protected readonly RecommendationStorageService $recommendationStorage,
+    protected readonly EntityTypeManagerInterface $entityTypeManager,
+    protected readonly DateFormatterInterface $dateFormatter,
+  ) {
+    parent::__construct();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container): self {
+    return new self(
+      $container->get('ai_content_strategy.recommendation_storage'),
+      $container->get('entity_type.manager'),
+      $container->get('date.formatter'),
+    );
+  }
+
+  /**
+   * Gets the full content strategy report.
+   */
+  #[CLI\Command(name: 'acs:report', aliases: ['acs-r', 'acs:recommendations'])]
+  #[CLI\Help(
+    description: 'Gets the full AI content strategy report with all categories and recommendations.',
+    synopsis: <<<'END'
+
+## Purpose
+
+Returns the complete AI-generated content strategy report as structured JSON.
+Designed for AI assistant consumption to understand content recommendations.
+
+## What This Command Returns
+
+The full report includes:
+- Generation metadata (timestamp, pages analyzed)
+- All recommendation categories (dynamically configured)
+- Cards within each category with content ideas
+- Implementation status for each idea
+
+## Output Structure
+
+```json
+{
+  "success": true,
+  "generated_at": "2024-01-30T12:00:00+00:00",
+  "generated_ago": "2 hours ago",
+  "pages_analyzed": 150,
+  "categories": {
+    "content_gaps": {
+      "id": "content_gaps",
+      "label": "Content Gaps",
+      "description": "Identifies missing content opportunities...",
+      "weight": 0,
+      "card_count": 5,
+      "cards": [
+        {
+          "uuid": "abc-123-def",
+          "title": "Product Comparison Pages",
+          "content_ideas": [
+            {
+              "uuid": "ghi-456-jkl",
+              "text": "Create comparison: Product A vs Product B",
+              "implemented": false,
+              "link": ""
+            },
+            {
+              "uuid": "mno-789-pqr",
+              "text": "Add feature matrix table",
+              "implemented": true,
+              "link": "/node/123"
+            }
+          ]
+        }
+      ]
+    },
+    "topical_authority": {
+      "id": "topical_authority",
+      "label": "Topical Authority",
+      "description": "Build expertise in key topic areas...",
+      "weight": 1,
+      "card_count": 3,
+      "cards": [...]
+    }
+  },
+  "summary": {
+    "total_categories": 4,
+    "total_cards": 15,
+    "total_ideas": 47,
+    "implemented_ideas": 12,
+    "pending_ideas": 35
+  }
+}
+```
+
+## Category Structure
+
+Categories are **dynamically configured** via the admin UI at:
+`/admin/config/ai/content-strategy/categories`
+
+Each category has:
+- `id`: Machine name
+- `label`: Human-readable name
+- `description`: What this category analyzes
+- `weight`: Sort order
+- `cards`: Array of recommendation cards
+
+## Card Structure
+
+Each card represents a content recommendation:
+- `uuid`: Unique identifier for the card
+- `title`: The recommendation title/topic
+- `content_ideas`: Array of specific content ideas
+
+## Idea Structure
+
+Each idea is an actionable content suggestion:
+- `uuid`: Unique identifier
+- `text`: The content idea description
+- `implemented`: Boolean - whether this has been done
+- `link`: URL to the created content (if implemented)
+
+## Examples
+
+### Get Full Report
+```bash
+drush acs:report --format=json
+```
+
+### Save Report to File
+```bash
+drush acs:report --format=json > content-strategy.json
+```
+
+### Extract Specific Category with jq
+```bash
+drush acs:report --format=json | jq '.categories.content_gaps'
+```
+
+### Get Only Pending Ideas
+```bash
+drush acs:report --format=json | jq '[.categories[].cards[].content_ideas[] | select(.implemented == false)]'
+```
+
+### Count Ideas by Category
+```bash
+drush acs:report --format=json | jq '.categories | to_entries | map({category: .key, ideas: ([.value.cards[].content_ideas[]] | length)})'
+```
+
+## When No Report Exists
+
+If no report has been generated yet:
+```json
+{
+  "success": false,
+  "message": "No content strategy report has been generated yet. Generate one via the admin UI or API.",
+  "categories": {}
+}
+```
+
+## Use Cases for AI Assistants
+
+1. **Content Planning**: Review all recommendations before creating content
+2. **Progress Tracking**: Check which ideas have been implemented
+3. **Priority Assessment**: Analyze categories to focus efforts
+4. **Gap Analysis**: Identify areas needing more content
+5. **Reporting**: Generate status reports on content strategy progress
+
+## Related Commands
+
+- `acs:sitemap:urls` - Get all site URLs for context
+- `acs:sitemap:stats` - Quick site size check
+
+## Generating New Reports
+
+Reports are generated via:
+- Admin UI: `/admin/config/ai/content-strategy`
+- The generation process analyzes sitemap URLs with AI
+
+END
+  )]
+  #[CLI\Usage(name: 'drush acs:report --format=json', description: 'Get full content strategy report')]
+  #[CLI\Usage(name: 'drush acs:report --format=json > report.json', description: 'Save report to file')]
+  public function getReport(): array {
+    $storedData = $this->recommendationStorage->getStoredData();
+
+    // Handle case where no report exists.
+    if ($storedData === NULL || empty($storedData['data'])) {
+      return [
+        'success' => FALSE,
+        'message' => 'No content strategy report has been generated yet. Generate one via the admin UI at /admin/config/ai/content-strategy.',
+        'generated_at' => NULL,
+        'pages_analyzed' => NULL,
+        'categories' => [],
+        'summary' => [
+          'total_categories' => 0,
+          'total_cards' => 0,
+          'total_ideas' => 0,
+          'implemented_ideas' => 0,
+          'pending_ideas' => 0,
+        ],
+      ];
+    }
+
+    $recommendations = $storedData['data'];
+    $timestamp = $storedData['timestamp'] ?? NULL;
+    $pagesAnalyzed = $storedData['pages_analyzed'] ?? NULL;
+
+    // Load all enabled recommendation categories.
+    $categoryEntities = $this->entityTypeManager
+      ->getStorage('recommendation_category')
+      ->loadByProperties(['status' => TRUE]);
+
+    // Sort by weight.
+    uasort($categoryEntities, fn($a, $b) => $a->getWeight() <=> $b->getWeight());
+
+    // Build categories output.
+    $categories = [];
+    $totalCards = 0;
+    $totalIdeas = 0;
+    $implementedIdeas = 0;
+
+    foreach ($categoryEntities as $categoryId => $categoryEntity) {
+      $cards = $recommendations[$categoryId] ?? [];
+      $cardCount = count($cards);
+      $totalCards += $cardCount;
+
+      // Count ideas in this category.
+      foreach ($cards as &$card) {
+        $ideas = $card['content_ideas'] ?? [];
+        $totalIdeas += count($ideas);
+
+        // Normalize ideas and count implemented.
+        foreach ($ideas as $idea) {
+          if (is_array($idea) && !empty($idea['implemented'])) {
+            $implementedIdeas++;
+          }
+        }
+      }
+
+      $categories[$categoryId] = [
+        'id' => $categoryId,
+        'label' => $categoryEntity->label(),
+        'description' => $categoryEntity->getDescription(),
+        'weight' => $categoryEntity->getWeight(),
+        'card_count' => $cardCount,
+        'cards' => $cards,
+      ];
+    }
+
+    // Format timestamp.
+    $generatedAt = NULL;
+    $generatedAgo = NULL;
+    if ($timestamp) {
+      $generatedAt = date('c', $timestamp);
+      $generatedAgo = $this->dateFormatter->formatTimeDiffSince($timestamp);
+    }
+
+    return [
+      'success' => TRUE,
+      'generated_at' => $generatedAt,
+      'generated_ago' => $generatedAgo,
+      'pages_analyzed' => $pagesAnalyzed,
+      'categories' => $categories,
+      'summary' => [
+        'total_categories' => count($categories),
+        'total_cards' => $totalCards,
+        'total_ideas' => $totalIdeas,
+        'implemented_ideas' => $implementedIdeas,
+        'pending_ideas' => $totalIdeas - $implementedIdeas,
+      ],
+    ];
+  }
+
+  /**
+   * Lists available recommendation categories.
+   */
+  #[CLI\Command(name: 'acs:categories', aliases: ['acs-c'])]
+  #[CLI\Help(
+    description: 'Lists all configured recommendation categories.',
+    synopsis: <<<'END'
+
+## Purpose
+
+Lists all recommendation categories configured in the system.
+Categories are dynamically configurable and define what types
+of content recommendations the AI generates.
+
+## Output Structure
+
+```json
+[
+  {
+    "id": "content_gaps",
+    "label": "Content Gaps",
+    "description": "Identifies missing content...",
+    "weight": 0,
+    "status": true
+  }
+]
+```
+
+## Examples
+
+```bash
+drush acs:categories --format=json
+```
+
+## Managing Categories
+
+Categories are managed at:
+`/admin/config/ai/content-strategy/categories`
+
+END
+  )]
+  #[CLI\Usage(name: 'drush acs:categories --format=json', description: 'List all categories')]
+  public function listCategories(): array {
+    $categoryEntities = $this->entityTypeManager
+      ->getStorage('recommendation_category')
+      ->loadMultiple();
+
+    // Sort by weight.
+    uasort($categoryEntities, fn($a, $b) => $a->getWeight() <=> $b->getWeight());
+
+    $categories = [];
+    foreach ($categoryEntities as $categoryEntity) {
+      $categories[] = [
+        'id' => $categoryEntity->id(),
+        'label' => $categoryEntity->label(),
+        'description' => $categoryEntity->getDescription(),
+        'weight' => $categoryEntity->getWeight(),
+        'status' => $categoryEntity->status(),
+      ];
+    }
+
+    return $categories;
+  }
+
+}


### PR DESCRIPTION
## Summary

- Adds `acs:report` and `acs:sitemap` Drush commands designed for AI coding assistant consumption
- Includes comprehensive help text with examples for AI tools
- Outputs JSON-only format (no --format option needed)
- Adds warning messages when sitemap is unavailable or has fewer than 5 URLs

## Test plan

- [ ] Run `drush acs:report` and verify JSON output
- [ ] Run `drush acs:sitemap -l https://your-site.com` and verify JSON output
- [ ] Run `drush help acs:report` and verify comprehensive help text
- [ ] Verify warning appears when sitemap has < 5 URLs
- [ ] Verify warning appears when sitemap is unavailable

Closes #15
Closes #17