### PR TITLE
Replace hardcoded CSS colors with Claro/Gin theme variables

### DIFF
--- a/css/components/base.css
+++ b/css/components/base.css
@@ -1,6 +1,9 @@
 /**
  * @file
  * Base layout styles for AI Content Strategy.
+ *
+ * Uses Gin CSS variables (dark mode aware) with Claro fallbacks
+ * and hardcoded last-resort values.
  */
 
 /* Main Container */
@@ -13,7 +16,7 @@
 .content-strategy-description {
   margin-bottom: 2em;
   font-size: 1.1em;
-  color: #666;
+  color: var(--gin-color-text-light, var(--color-text-light, #545560));
 }
 
 /* Status Area */
@@ -22,9 +25,9 @@
   flex-wrap: wrap;
   gap: 2rem;
   padding: 1rem;
-  background: #f8f9fa;
-  border: 1px solid #e5e7eb;
-  border-radius: 6px;
+  background: var(--gin-bg-layer2, var(--color-gray-050, #f3f4f9));
+  border: 1px solid var(--gin-border-color-layer, var(--color-gray-200, #d3d4d9));
+  border-radius: var(--base-border-radius, 2px);
   margin-bottom: 1.5rem;
 }
 
@@ -36,12 +39,12 @@
 }
 
 .status-item strong {
-  color: #374151;
+  color: var(--gin-color-text, var(--color-text, #232429));
   font-weight: 600;
 }
 
 .status-item:not(strong) {
-  color: #6b7280;
+  color: var(--gin-color-text-light, var(--color-text-light, #545560));
 }
 
 /* Actions */
@@ -56,7 +59,7 @@
 .empty-recommendations {
   text-align: center;
   padding: 3rem;
-  background: #f9fafb;
-  border-radius: 8px;
-  color: #6b7280;
+  background: var(--gin-bg-layer2, var(--color-gray-050, #f3f4f9));
+  border-radius: var(--base-border-radius, 2px);
+  color: var(--gin-color-text-light, var(--color-text-light, #545560));
 }

--- a/css/components/cards.css
+++ b/css/components/cards.css
@@ -1,14 +1,17 @@
 /**
  * @file
  * Recommendation card styles for AI Content Strategy.
+ *
+ * Uses Gin CSS variables (dark mode aware) with Claro fallbacks
+ * and hardcoded last-resort values.
  */
 
 /* Recommendations Grid */
 .recommendation-items {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
-  gap: 1.5rem;
-  margin-top: 1.5rem;
+  gap: var(--space-l, 1.5rem);
+  margin-top: var(--space-l, 1.5rem);
 }
 
 @media screen and (max-width: 768px) {
@@ -19,11 +22,11 @@
 
 /* Recommendation Cards */
 .recommendation-item {
-  background: white;
-  padding: 1.5rem;
-  border: 1px solid #e0e0e0;
-  border-radius: 8px;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  background: var(--gin-bg-layer, var(--color-white, #fff));
+  padding: var(--space-l, 1.5rem);
+  border: 1px solid var(--gin-border-color-layer, var(--color-gray-200, #d3d4d9));
+  border-radius: var(--base-border-radius, 2px);
+  box-shadow: var(--gin-shadow-l1, var(--details-box-shadow, 0 2px 4px rgba(0, 0, 0, 0.1)));
 }
 
 .recommendation-header {
@@ -41,7 +44,7 @@
 
 .recommendation-item p {
   margin-bottom: 1rem;
-  color: #4a4a4a;
+  color: var(--gin-color-text-light, var(--color-text-light, #545560));
 }
 
 /* Recommendation Actions */
@@ -64,19 +67,19 @@
 }
 
 .priority-badge.high {
-  background-color: #fef2f2;
-  color: #dc2626;
-  border: 1px solid #fecaca;
+  background-color: var(--gin-color-danger-lightest, var(--color-red-020, #fdf5f5));
+  color: var(--gin-color-danger, var(--color-maximumred, #dc2323));
+  border: 1px solid var(--gin-color-danger-light, var(--color-red-100, #f8d3d3));
 }
 
 .priority-badge.medium {
-  background-color: #fffbeb;
-  color: #d97706;
-  border: 1px solid #fef3c7;
+  background-color: var(--gin-bg-warning-light, rgba(226, 151, 0, 0.08));
+  color: var(--gin-color-warning, var(--color-sunglow-shaded, #977405));
+  border: 1px solid var(--gin-color-warning-light, rgba(226, 151, 0, 0.2));
 }
 
 .priority-badge.low {
-  background-color: #f0fdf4;
-  color: #16a34a;
-  border: 1px solid #dcfce7;
+  background-color: var(--gin-bg-green-light, rgba(72, 171, 123, 0.1));
+  color: var(--gin-color-green, var(--color-lightninggreen, #26a769));
+  border: 1px solid var(--gin-color-green-light, rgba(72, 171, 123, 0.3));
 }

--- a/css/components/checkbox.css
+++ b/css/components/checkbox.css
@@ -1,6 +1,9 @@
 /**
  * @file
  * Checkbox styles for AI Content Strategy implemented status.
+ *
+ * Uses Claro's .form-boolean class for native checkbox styling.
+ * Only layout overrides needed for table context.
  */
 
 /* Idea Checkbox */
@@ -9,53 +12,4 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-}
-
-.idea-checkbox input[type="checkbox"] {
-  position: absolute;
-  opacity: 0;
-  width: 0;
-  height: 0;
-}
-
-.idea-checkbox-visual {
-  display: inline-block;
-  width: 25px;
-  height: 25px;
-  border: 2px solid #d1d5db;
-  border-radius: 4px;
-  background-color: #fff;
-  transition: all 0.15s ease;
-  position: relative;
-}
-
-.idea-checkbox-visual::after {
-  content: '';
-  position: absolute;
-  display: none;
-  left: 8px;
-  top: 3px;
-  width: 6px;
-  height: 12px;
-  border: solid #fff;
-  border-width: 0 2.5px 2.5px 0;
-  transform: rotate(45deg);
-}
-
-.idea-checkbox input[type="checkbox"]:checked + .idea-checkbox-visual {
-  background-color: #16a34a;
-  border-color: #16a34a;
-}
-
-.idea-checkbox input[type="checkbox"]:checked + .idea-checkbox-visual::after {
-  display: block;
-}
-
-.idea-checkbox:hover .idea-checkbox-visual {
-  border-color: #16a34a;
-}
-
-.idea-checkbox input[type="checkbox"]:focus + .idea-checkbox-visual {
-  outline: 2px solid #16a34a;
-  outline-offset: 2px;
 }

--- a/css/components/delete.css
+++ b/css/components/delete.css
@@ -10,13 +10,13 @@
   padding: 0;
   width: 25px;
   height: 25px;
-  color: #dc2626;
+  color: var(--gin-color-danger, var(--color-maximumred, #dc2323));
   cursor: pointer;
   transition: all 0.2s ease;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
+  border-radius: var(--base-border-radius, 2px);
   opacity: 0;
 }
 
@@ -26,7 +26,7 @@
 
 .delete-idea-link:hover {
   opacity: 1 !important;
-  background-color: #fee2e2;
+  background-color: var(--gin-color-danger-lightest, var(--color-red-050, #fce9e9));
 }
 
 /* Legacy SVG support - can be removed when all icons use CSS mask-image */
@@ -39,7 +39,7 @@
 }
 
 .delete-idea-link:focus {
-  outline: 2px solid #dc2626;
+  outline: 2px solid var(--gin-color-danger, var(--color-maximumred, #dc2323));
   outline-offset: 2px;
   opacity: 1;
 }
@@ -49,13 +49,13 @@
   background: none;
   border: none;
   padding: 0.5rem;
-  color: #dc2626;
+  color: var(--gin-color-danger, var(--color-maximumred, #dc2323));
   cursor: pointer;
   transition: all 0.2s ease;
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: 4px;
+  border-radius: var(--base-border-radius, 2px);
   flex-shrink: 0;
   opacity: 0;
 }
@@ -66,8 +66,8 @@
 
 .delete-card-link:hover {
   opacity: 1 !important;
-  color: #991b1b;
-  background-color: #fee2e2;
+  color: var(--color-maximumred-hover, #c61f1f);
+  background-color: var(--gin-color-danger-lightest, var(--color-red-050, #fce9e9));
 }
 
 .delete-card-link svg {
@@ -81,8 +81,8 @@
 }
 
 .delete-card-link:focus {
-  outline: 2px solid #dc2626;
+  outline: 2px solid var(--gin-color-danger, var(--color-maximumred, #dc2323));
   outline-offset: 2px;
-  color: #dc2626;
+  color: var(--gin-color-danger, var(--color-maximumred, #dc2323));
   opacity: 1;
 }

--- a/css/components/editable.css
+++ b/css/components/editable.css
@@ -11,21 +11,21 @@
 }
 
 .editable-field:hover {
-  outline: 1px dashed #ccc;
+  outline: 1px dashed var(--gin-border-color-layer2, var(--color-gray-300, #c1c2c7));
   outline-offset: 2px;
 }
 
 .editable-field:focus {
-  outline: 2px solid #0073aa;
+  outline: 2px solid var(--gin-color-primary, var(--color-link, #003ecc));
   outline-offset: 2px;
-  background-color: #f9f9f9;
+  background-color: var(--gin-bg-layer2, var(--color-gray-050, #f3f4f9));
 }
 
 /* Editable Field States */
 .editable-field--saving {
-  outline: 2px solid #0073aa;
+  outline: 2px solid var(--gin-color-primary, var(--color-link, #003ecc));
   outline-offset: 2px;
-  background-color: #f0f7ff;
+  background-color: var(--color-blue-020, #f5f8ff);
 }
 
 .editable-field--saved {
@@ -35,7 +35,7 @@
 @keyframes field-saved-flash {
   0% {
     background-color: #d4edda;
-    outline: 2px solid #28a745;
+    outline: 2px solid var(--gin-color-green, var(--color-lightninggreen, #26a769));
     outline-offset: 2px;
   }
   100% {
@@ -64,7 +64,7 @@
 /* Checkmark Icon */
 .field-save-indicator__checkmark {
   display: inline-flex;
-  color: #28a745;
+  color: var(--gin-color-green, var(--color-lightninggreen, #26a769));
   animation: checkmark-appear 0.3s ease-out;
 }
 
@@ -76,7 +76,7 @@
 /* Error Icon */
 .field-save-indicator__error {
   display: inline-flex;
-  color: #dc2626;
+  color: var(--gin-color-danger, var(--color-maximumred, #dc2323));
 }
 
 .field-save-indicator__error svg {

--- a/css/components/icons.css
+++ b/css/components/icons.css
@@ -79,11 +79,11 @@
 .field-save-indicator__checkmark .cs-icon {
   width: 16px;
   height: 16px;
-  background-color: #28a745;
+  background-color: var(--gin-color-green, var(--color-lightninggreen, #26a769));
 }
 
 .field-save-indicator__error .cs-icon {
   width: 16px;
   height: 16px;
-  background-color: #dc2626;
+  background-color: var(--gin-color-danger, var(--color-maximumred, #dc2323));
 }

--- a/css/components/links.css
+++ b/css/components/links.css
@@ -15,7 +15,7 @@
 }
 
 .idea-link {
-  color: #0073aa;
+  color: var(--gin-color-primary, var(--color-link, #003ecc));
   text-decoration: none;
   word-break: break-all;
   margin-right: 6px;
@@ -29,7 +29,7 @@
   background: none;
   border: none;
   padding: 2px;
-  color: #6b7280;
+  color: var(--gin-color-text-light, var(--color-text-light, #545560));
   cursor: pointer;
   vertical-align: middle;
   display: inline-flex;
@@ -42,10 +42,10 @@
 }
 
 .idea-link-edit:hover {
-  color: #0073aa;
+  color: var(--gin-color-primary, var(--color-link, #003ecc));
 }
 
-/* Idea Link Input */
+/* Idea Link Input - uses form-element class for base styling */
 .idea-link-input-wrapper {
   display: flex;
   align-items: center;
@@ -55,14 +55,5 @@
 
 .idea-link-input {
   flex: 1;
-  padding: 4px 8px;
-  border: 1px solid #d1d5db;
-  border-radius: 4px;
   font-size: 0.9em;
-}
-
-.idea-link-input:focus {
-  outline: none;
-  border-color: #0073aa;
-  box-shadow: 0 0 0 2px rgba(0, 115, 170, 0.2);
 }

--- a/css/components/table.css
+++ b/css/components/table.css
@@ -15,8 +15,8 @@
   padding: 0.5rem;
   font-size: 0.9em;
   font-weight: 600;
-  color: #374151;
-  border-bottom: 2px solid #e5e7eb;
+  color: var(--gin-color-text, var(--color-text, #232429));
+  border-bottom: 2px solid var(--gin-border-color-layer2, var(--color-gray-200, #d3d4d9));
 }
 
 .content-ideas-table thead .idea-actions-header {
@@ -25,12 +25,12 @@
 }
 
 .content-ideas-table tbody tr {
-  border-bottom: 1px solid #f3f4f6;
+  border-bottom: 1px solid var(--gin-border-color-layer, var(--color-gray-050, #f3f4f9));
   transition: background-color 0.15s ease;
 }
 
 .content-ideas-table tbody tr:hover {
-  background-color: #f9fafb;
+  background-color: var(--gin-bg-layer2, var(--color-gray-050, #f3f4f9));
 }
 
 .content-ideas-table tbody td {
@@ -55,12 +55,12 @@
 
 /* Implemented Row Styling */
 .content-ideas-table tbody tr.idea-implemented {
-  background-color: #f0fdf4;
+  background-color: var(--gin-bg-green-light, #f0fdf4);
 }
 
 .content-ideas-table tbody tr.idea-implemented .editable-field {
   text-decoration: line-through;
-  color: #6b7280;
+  color: var(--gin-color-text-light, var(--color-text-light, #545560));
 }
 
 .content-ideas-table tbody tr.idea-implemented:hover {

--- a/js/content-strategy-links.js
+++ b/js/content-strategy-links.js
@@ -26,7 +26,7 @@
     // Generate link input HTML (this stays client-side as it's temporary UI).
     const linkInputHTML = `
       <div class="idea-link-input-wrapper">
-        <input type="url" class="idea-link-input form-url" placeholder="${translations.enterUrl || Drupal.t('Enter URL...')}" value="${currentLink}">
+        <input type="url" class="idea-link-input form-element form-url" placeholder="${translations.enterUrl || Drupal.t('Enter URL...')}" value="${currentLink}">
         <button type="button" class="button button--small button--primary idea-link-save">${translations.save || Drupal.t('Save')}</button>
         <button type="button" class="button button--small idea-link-cancel">${translations.cancel || Drupal.t('Cancel')}</button>
       </div>

--- a/templates/components/idea-row.html.twig
+++ b/templates/components/idea-row.html.twig
@@ -35,9 +35,8 @@
     </div>
   </td>
   <td class="idea-actions">
-    <label class="idea-checkbox" title="{{ 'Mark as implemented'|t }}">
-      <input type="checkbox" class="idea-implemented-checkbox" data-section="{{ section }}" data-uuid="{{ uuid }}" data-idea-uuid="{{ idea_uuid }}"{{ idea_implemented ? ' checked' : '' }}>
-      <span class="idea-checkbox-visual"></span>
+    <label class="idea-checkbox form-type--checkbox" title="{{ 'Mark as implemented'|t }}">
+      <input type="checkbox" class="idea-implemented-checkbox form-boolean form-boolean--type-checkbox" data-section="{{ section }}" data-uuid="{{ uuid }}" data-idea-uuid="{{ idea_uuid }}"{{ idea_implemented ? ' checked' : '' }}>
     </label>
     <button type="button" class="delete-idea-link" data-section="{{ section }}" data-uuid="{{ uuid }}" data-idea-uuid="{{ idea_uuid }}" title="{{ 'Delete this content idea'|t }}" aria-label="{{ 'Delete content idea'|t }}">
       <span class="cs-icon cs-icon--trash cs-icon--md" aria-hidden="true"></span>

--- a/templates/components/link-input.html.twig
+++ b/templates/components/link-input.html.twig
@@ -10,7 +10,7 @@
  */
 #}
 <div class="idea-link-input-wrapper">
-  <input type="url" class="idea-link-input form-url" placeholder="{{ 'Enter URL...'|t }}" value="{{ current_link }}">
+  <input type="url" class="idea-link-input form-element form-url" placeholder="{{ 'Enter URL...'|t }}" value="{{ current_link }}">
   <button type="button" class="button button--small button--primary idea-link-save">{{ 'Save'|t }}</button>
   <button type="button" class="button button--small idea-link-cancel">{{ 'Cancel'|t }}</button>
 </div>


### PR DESCRIPTION
## Summary

Closes #22

- Replace all hardcoded hex colors across 8 CSS files with shared Claro/Gin CSS variables using triple-layered fallbacks (`--gin-*`, `--color-*`, hardcoded) for dark mode support and theme compatibility
- Use Claro's `form-boolean` class for checkboxes, removing ~50 lines of custom checkbox CSS
- Use Claro's `form-element` class for link inputs, removing custom border/focus styling
- Priority badges now use transparent background colors that adapt to both light and dark mode

## Test plan

- [ ] Verify page renders correctly in Gin light mode
- [ ] Verify page renders correctly in Gin dark mode
- [ ] Verify priority badges (HIGH/MEDIUM/LOW) are readable in both modes
- [ ] Verify checkboxes work (check/uncheck toggles implemented state)
- [ ] Verify link input appears correctly when clicking "+ Add link"
- [ ] Verify delete buttons show on hover with correct red styling
- [ ] Verify editable fields show focus/hover outlines